### PR TITLE
All minor linting warning have been removed

### DIFF
--- a/core/i18n/request.ts
+++ b/core/i18n/request.ts
@@ -17,7 +17,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
   if (locale === fallbackLocale) {
     return {
       locale,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       messages: (await import(`../messages/${locale}.json`)).default,
     };
   }

--- a/core/tests/fixtures/page.ts
+++ b/core/tests/fixtures/page.ts
@@ -104,7 +104,6 @@ export async function toHaveURL(
     pass,
     name: assertionName,
     expected: url,
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     actual: matcherResult?.actual,
   };
 }

--- a/core/vibes/soul/sections/products-list-section/filters-panel.tsx
+++ b/core/vibes/soul/sections/products-list-section/filters-panel.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 'use client';
 
 import { clsx } from 'clsx';


### PR DESCRIPTION
## What/Why?
  1. ✅ Removed unused @typescript-eslint/no-unsafe-assignment from core/i18n/request.ts:20
  2. ✅ Removed unused @typescript-eslint/no-unsafe-assignment from
  core/tests/fixtures/page.ts:107
  3. ✅ Removed unused @typescript-eslint/no-unsafe-assignment from
  core/vibes/soul/sections/products-list-section/filters-panel.tsx:4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unnecessary ESLint directive comments from various files. No changes to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->