### PR TITLE
Updated text casing in header

### DIFF
--- a/core/components/header/index.tsx
+++ b/core/components/header/index.tsx
@@ -113,7 +113,7 @@ export const Header = async () => {
     });
 
     return slicedTree.map(({ name, path, children }) => ({
-      label: name.toLocaleLowerCase(),
+      label: name.toLocaleLowerCase(locale),
       href: path,
       groups: children.map((firstChild) => ({
         label: firstChild.name,

--- a/core/components/header/index.tsx
+++ b/core/components/header/index.tsx
@@ -107,13 +107,13 @@ export const Header = async () => {
     //  adding unique home link
 
     slicedTree.unshift({
-      name: 'home',
+      name: 'Home',
       path: '/',
       children: [],
     });
 
     return slicedTree.map(({ name, path, children }) => ({
-      label: name,
+      label: name.toLocaleLowerCase(),
       href: path,
       groups: children.map((firstChild) => ({
         label: firstChild.name,

--- a/core/vibes/soul/sections/page-header/index.tsx
+++ b/core/vibes/soul/sections/page-header/index.tsx
@@ -60,7 +60,7 @@ export const PageHeader = ({ title, backgroundImage, className }: PageHeaderProp
         >
           {(pageTitle) => (
               <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold font-['Nunito'] font-heading leading-tight text-black/70">
-              {pageTitle}
+              {pageTitle.toLocaleLowerCase()}
               <span className='text-[#F92F7B] text-5xl md:text-6xl lg:text-7xl font-["Inter"] leading-[67.20px]'>
                 .
               </span>

--- a/core/vibes/soul/sections/page-header/index.tsx
+++ b/core/vibes/soul/sections/page-header/index.tsx
@@ -8,9 +8,10 @@ interface PageHeaderProps {
   backgroundImage?: Streamable<{ src: string; alt: string } | null>;
   className?: string;
   title: Streamable<string>;
+  locale?: string;
 }
 
-export const PageHeader = ({ title, backgroundImage, className }: PageHeaderProps) => {
+export const PageHeader = ({ title, backgroundImage, className, locale }: PageHeaderProps) => {
   const placeholderImage = {
     alt: 'Page header background',
     src: '/images/backgrounds/newsletter-background.svg'
@@ -60,7 +61,7 @@ export const PageHeader = ({ title, backgroundImage, className }: PageHeaderProp
         >
           {(pageTitle) => (
               <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold font-['Nunito'] font-heading leading-tight text-black/70">
-              {pageTitle.toLocaleLowerCase()}
+              {pageTitle.toLocaleLowerCase(locale)}
               <span className='text-[#F92F7B] text-5xl md:text-6xl lg:text-7xl font-["Inter"] leading-[67.20px]'>
                 .
               </span>


### PR DESCRIPTION
Closes #35 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Navigation link labels in the header are now displayed in lowercase.
  * The "Home" link in the header is capitalized but displayed in lowercase.
  * Page titles in section headers are now shown in lowercase according to locale settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->