### PR TITLE
Crop product images to square using object-cover

### DIFF
--- a/core/vibes/soul/primitives/product-card/index.tsx
+++ b/core/vibes/soul/primitives/product-card/index.tsx
@@ -87,7 +87,7 @@ export function ProductCard({
           {imageUrl ? (
             <Image
               alt={productName || 'Product image'}
-              className="object-contain"
+              className="object-cover"
               fill
               loading="lazy"
               priority={imagePriority}


### PR DESCRIPTION
Crop product images to square using object-cover

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated product card images to fill their containers for a more immersive, edge-to-edge presentation. This reduces empty spacing/letterboxing across grids and lists and may introduce slight edge cropping to preserve aspect ratios. Applies wherever product cards appear (e.g., home, category, and search views). No changes to behavior, controls, or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->