### PR TITLE
Prevent payment options background layout shift

### DIFF
--- a/core/components/payment-options/index.tsx
+++ b/core/components/payment-options/index.tsx
@@ -18,10 +18,10 @@ export function PaymentOptions() {
         <Image
           alt=""
           aria-hidden="true"
-          className="absolute inset-0 w-full h-full object-cover opacity-90"
-          fill
-          priority={false}
+          className="absolute top-0 left-0 w-full h-screen object-cover object-top opacity-95"
+          height={1080}
           src="/images/backgrounds/newsletter-form.webp"
+          width={1920}
         />
 
         <div className="relative flex flex-col h-full p-6 sm:p-8">

--- a/core/components/payment-options/index.tsx
+++ b/core/components/payment-options/index.tsx
@@ -18,8 +18,9 @@ export function PaymentOptions() {
         <Image
           alt=""
           aria-hidden="true"
-          className="absolute top-0 left-0 w-full h-screen object-cover object-top opacity-95"
+          className="absolute top-0 left-0 w-full h-screen object-cover object-top opacity-95 brightness-95 pointer-events-none select-none"
           height={1080}
+          sizes="(min-width: 556px) 500px, 90vw"
           src="/images/backgrounds/newsletter-form.webp"
           width={1920}
         />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Updated the Payment Options background image to use explicit fixed dimensions and top-left anchoring, covering the full screen height.
  - Increased opacity and brightness for improved readability.
  - Prevented image interaction (non-clickable) to avoid accidental input.
  - Replaced fill-based scaling to reduce cropping/stretching and improve visual consistency across devices.
  - No changes to functionality or user flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->