### PR TITLE
override margin left to 0

### DIFF
--- a/core/components/product-showcase/index.tsx
+++ b/core/components/product-showcase/index.tsx
@@ -144,7 +144,10 @@ export function ProductShowcase({
               }}
               setApi={setCarouselApi}
             >
-              <CarouselContent className="w-full carousel-content" style={{ marginLeft: '0px' }}>
+              <CarouselContent
+                className="w-full carousel-content"
+                style={{ marginInlineStart: 0, marginLeft: 0 }}
+              >
                 {showcaseImages.map((image, index) => (
                   <CarouselItem
                     className="relative flex w-full items-center justify-center p-0 basis-full carousel-item"


### PR DESCRIPTION
Closes #174 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixes unintended left offset in the product carousel so slides start at the expected position, improving alignment and preventing partial clipping across layouts and languages.

* **Style**
  * Standardizes carousel spacing by explicitly zeroing left/start margin, yielding cleaner visual balance, smoother transitions, and reduced layout shift for a more polished browsing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->