### PR TITLE
removed padding 1.5 from carousel primitive

### DIFF
--- a/core/vibes/soul/primitives/carousel/index.tsx
+++ b/core/vibes/soul/primitives/carousel/index.tsx
@@ -118,7 +118,7 @@ function Carousel({
       <div
         {...props}
         aria-roledescription="carousel"
-        className={clsx('@container relative p-1.5', hideOverflow && 'overflow-hidden', className)}
+        className={clsx('@container relative', hideOverflow && 'overflow-hidden', className)}
         onKeyDownCapture={handleKeyDown}
         role="region"
       >


### PR DESCRIPTION
removed padding 1.5 from carousel primitive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Carousel layout by removing inner padding, resulting in a tighter, edge-to-edge presentation.
  * Improves visual alignment with surrounding content and can display slightly more content within the same space.
  * No changes to interactions or behavior; scrolling and overflow handling remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->