### PR TITLE
hide compare performance pulsing rings on mobile

### DIFF
--- a/core/components/product/layout/performance-comparison/performance-comparison.tsx
+++ b/core/components/product/layout/performance-comparison/performance-comparison.tsx
@@ -187,7 +187,7 @@ export function PerformanceComparison({
             {/* Static rings for mobile - positioned relative to image (only if not disabled) */}
             {!performanceConfig.disabledOnMobile && (
               <div
-                className="absolute pointer-events-none xl:hidden"
+                className="absolute pointer-events-none"
                 style={{
                   left: `${((mergedWheelConfig.centerX + (mergedWheelConfig.mobileOffsetX || 0)) / mergedImageConfig.width) * 100}%`,
                   top: `${((mergedWheelConfig.centerY + (mergedWheelConfig.mobileOffsetY || 0)) / mergedImageConfig.height) * 100}%`,

--- a/core/components/product/layout/performance-comparison/performance-comparison.tsx
+++ b/core/components/product/layout/performance-comparison/performance-comparison.tsx
@@ -184,15 +184,16 @@ export function PerformanceComparison({
               />
             </div>
 
-            {/* Static rings for mobile - positioned relative to image */}
-            <div
-              className="absolute pointer-events-none xl:hidden"
-              style={{
-                left: `${((mergedWheelConfig.centerX + (mergedWheelConfig.mobileOffsetX || 0)) / mergedImageConfig.width) * 100}%`,
-                top: `${((mergedWheelConfig.centerY + (mergedWheelConfig.mobileOffsetY || 0)) / mergedImageConfig.height) * 100}%`,
-                transform: 'translate(-50%, -50%) scale(0.3)',
-              }}
-            >
+            {/* Static rings for mobile - positioned relative to image (only if not disabled) */}
+            {!performanceConfig.disabledOnMobile && (
+              <div
+                className="absolute pointer-events-none xl:hidden"
+                style={{
+                  left: `${((mergedWheelConfig.centerX + (mergedWheelConfig.mobileOffsetX || 0)) / mergedImageConfig.width) * 100}%`,
+                  top: `${((mergedWheelConfig.centerY + (mergedWheelConfig.mobileOffsetY || 0)) / mergedImageConfig.height) * 100}%`,
+                  transform: 'translate(-50%, -50%) scale(0.3)',
+                }}
+              >
               <div
                 style={{
                   position: 'relative',
@@ -245,6 +246,7 @@ export function PerformanceComparison({
                 ))}
               </div>
             </div>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
hide compare performance pulsing rings on mobile


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile view now respects the performance setting and hides static performance rings when disabled, preventing unintended display on some devices.
  * Reduces visual clutter on mobile for users who have the feature turned off.
  * Desktop experience and other behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->